### PR TITLE
Harden batch runtime validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ This is the reference model — pure `Map[BigInt, BigInt]`, no arrays, no mutati
 Production implementations are **not themselves formally verified**. They are tested for correctness:
 
 - **`Interpreter.scala`** (pure Map-based) — property-based tests (ScalaCheck, 100+ random scenarios per property)
-- **`ImperativeInterpreter.scala`** (Array-based, fast) — tested for bit-for-bit equivalence with `Interpreter.scala` via `EquivalenceSpec`
-- **`Distribute.scala`** (N-way distribution with residual plug) — property-based tests proving `sum == total` for arbitrary N
+- **`ImperativeInterpreter.scala`** (Array-based, fast) — tested for bit-for-bit equivalence with `Interpreter.scala` via `EquivalenceSpec`, with runtime validation of batch dimensions, indices, and non-negative amounts
+- **`Distribute.scala`** (N-way distribution with residual plug) — property-based tests checking `sum == total` for arbitrary N
 
 The chain of trust:
 
 ```
 Stainless/Z3 proves → Verified.scala (reference model)
 EquivalenceSpec tests → ImperativeInterpreter == Interpreter (bit-for-bit)
-InterpreterPropertySpec tests → Interpreter satisfies same properties as Verified.scala
+InterpreterPropertySpec tests → Interpreter checks analogous properties to Verified.scala
 ```
 
 **Important distinction:** `EquivalenceSpec` is a test, not a formal proof. It provides strong empirical evidence but not mathematical certainty that the production interpreter matches the verified model.
@@ -43,7 +43,7 @@ InterpreterPropertySpec tests → Interpreter satisfies same properties as Verif
 ### Layer 3: Not yet formally verified
 
 - N-way `distribute()` — proved for 2 and 3 recipients in Stainless, tested for arbitrary N via ScalaCheck
-- `BatchedFlow` index bounds — enforced by `require()` at runtime, not formally verified
+- Batch dimensions, sender/target index bounds, and non-negative amounts — enforced at runtime by `ImperativeInterpreter.validateBatch`, not formally verified
 - `MutableWorldState` — tested via equivalence, not formally verified (mutable state is hard to verify in SMT solvers)
 
 ### Why pointwise, not global sum?
@@ -93,12 +93,12 @@ sbt test
 - **Stainless** (EPFL) — formal verification for Scala, powered by Z3
 - **Z3** (Microsoft Research) — SMT solver
 - **ScalaCheck** — property-based testing
-- **Long-based arithmetic** — all amounts are `Long` (scale 10^4), addition is exact
+- **Long-based arithmetic** — all amounts are `Long` (scale 10^4), avoiding floating-point error within bounded integer arithmetic
 
 ## Part of the amor-fati ecosystem
 
 - [amor-fati](https://github.com/boombustgroup/amor-fati) — macroeconomic SFC-ABM simulation engine
-- **amor-fati-ledger-poc** — this repo (verified flow interpreter)
+- **amor-fati-ledger-poc** — this repo (ledger POC with a formally verified reference core)
 
 ## License
 

--- a/src/main/scala/com/boombustgroup/ledger/ImperativeInterpreter.scala
+++ b/src/main/scala/com/boombustgroup/ledger/ImperativeInterpreter.scala
@@ -10,31 +10,66 @@ package com.boombustgroup.ledger
   */
 object ImperativeInterpreter:
 
-  /** Apply a single batched flow. O(N) where N = amounts.length. */
-  def applyBatch(state: MutableWorldState, batch: BatchedFlow): Unit = batch match
-    case BatchedFlow.Scatter(from, to, amounts, targets, asset, _) =>
-      val fromStore = state.getBalances(from, asset)
-      val toStore   = state.getBalances(to, asset)
-      var i         = 0
+  private def validateBatch(state: MutableWorldState, batch: BatchedFlow): Unit = batch match
+    case BatchedFlow.Scatter(from, to, amounts, targets, _, _) =>
+      val fromSize = state.sectorSize(from)
+      val toSize   = state.sectorSize(to)
+      require(
+        amounts.length == fromSize,
+        s"Scatter amounts.length=${amounts.length} must equal sectorSize($from)=$fromSize"
+      )
+      var i = 0
       while i < amounts.length do
-        val amount = amounts(i)
-        if amount != 0L then
-          fromStore(i) -= amount
-          toStore(targets(i)) += amount
+        require(amounts(i) >= 0L, s"Scatter amount at index $i is negative: ${amounts(i)}")
+        require(
+          targets(i) >= 0 && targets(i) < toSize,
+          s"Scatter target index at position $i out of bounds: ${targets(i)} for sectorSize($to)=$toSize"
+        )
         i += 1
 
-    case BatchedFlow.Broadcast(from, fromIdx, to, amounts, targets, asset, _) =>
-      val fromStore  = state.getBalances(from, asset)
-      val toStore    = state.getBalances(to, asset)
-      var i          = 0
-      var totalDebit = 0L
+    case BatchedFlow.Broadcast(from, fromIdx, to, amounts, targets, _, _) =>
+      val fromSize = state.sectorSize(from)
+      val toSize   = state.sectorSize(to)
+      require(
+        fromIdx >= 0 && fromIdx < fromSize,
+        s"Broadcast fromIndex=$fromIdx out of bounds for sectorSize($from)=$fromSize"
+      )
+      var i = 0
       while i < amounts.length do
-        val amount = amounts(i)
-        if amount != 0L then
-          totalDebit += amount
-          toStore(targets(i)) += amount
+        require(amounts(i) >= 0L, s"Broadcast amount at index $i is negative: ${amounts(i)}")
+        require(
+          targets(i) >= 0 && targets(i) < toSize,
+          s"Broadcast target index at position $i out of bounds: ${targets(i)} for sectorSize($to)=$toSize"
+        )
         i += 1
-      fromStore(fromIdx) -= totalDebit
+
+  /** Apply a single batched flow. O(N) where N = amounts.length. */
+  def applyBatch(state: MutableWorldState, batch: BatchedFlow): Unit =
+    validateBatch(state, batch)
+    batch match
+      case BatchedFlow.Scatter(from, to, amounts, targets, asset, _) =>
+        val fromStore = state.getBalances(from, asset)
+        val toStore   = state.getBalances(to, asset)
+        var i         = 0
+        while i < amounts.length do
+          val amount = amounts(i)
+          if amount != 0L then
+            fromStore(i) -= amount
+            toStore(targets(i)) += amount
+          i += 1
+
+      case BatchedFlow.Broadcast(from, fromIdx, to, amounts, targets, asset, _) =>
+        val fromStore  = state.getBalances(from, asset)
+        val toStore    = state.getBalances(to, asset)
+        var i          = 0
+        var totalDebit = 0L
+        while i < amounts.length do
+          val amount = amounts(i)
+          if amount != 0L then
+            totalDebit += amount
+            toStore(targets(i)) += amount
+          i += 1
+        fromStore(fromIdx) -= totalDebit
 
   /** Apply a sequence of batched flows. */
   def applyAll(state: MutableWorldState, flows: Vector[BatchedFlow]): Unit =

--- a/src/test/scala/com/boombustgroup/ledger/EquivalenceSpec.scala
+++ b/src/test/scala/com/boombustgroup/ledger/EquivalenceSpec.scala
@@ -75,6 +75,36 @@ class EquivalenceSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     }
   }
 
+  it should "reject scatter batches with invalid sender dimension" in {
+    val batch = BatchedFlow.Scatter(
+      HH,
+      Banks,
+      Array.fill(NumHH - 1)(100L),
+      Array.fill(NumHH - 1)(0),
+      Asset,
+      MechanismId(1)
+    )
+
+    val state = new MutableWorldState(Map(HH -> NumHH, Banks -> NumBanks))
+    an[IllegalArgumentException] should be thrownBy ImperativeInterpreter.applyBatch(state, batch)
+  }
+
+  it should "reject scatter batches with out-of-bounds target indices" in {
+    val targets = Array.fill(NumHH)(0)
+    targets(NumHH - 1) = NumBanks
+    val batch = BatchedFlow.Scatter(
+      HH,
+      Banks,
+      Array.fill(NumHH)(100L),
+      targets,
+      Asset,
+      MechanismId(1)
+    )
+
+    val state = new MutableWorldState(Map(HH -> NumHH, Banks -> NumBanks))
+    an[IllegalArgumentException] should be thrownBy ImperativeInterpreter.applyBatch(state, batch)
+  }
+
   // --- Broadcast (1:N) tests ---
 
   private val NumFunds = 7
@@ -133,4 +163,36 @@ class EquivalenceSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyC
     state.balance(HH, Asset, 0) shouldBe 10000L
     state.balance(HH, Asset, 1) shouldBe 20000L
     state.balance(HH, Asset, 2) shouldBe 30000L
+  }
+
+  it should "reject broadcast batches with invalid sender index" in {
+    val batch = BatchedFlow.Broadcast(
+      Funds,
+      NumFunds,
+      HH,
+      Array.fill(NumHH)(100L),
+      (0 until NumHH).toArray,
+      Asset,
+      MechanismId(2)
+    )
+
+    val state = new MutableWorldState(Map(HH -> NumHH, Funds -> NumFunds))
+    an[IllegalArgumentException] should be thrownBy ImperativeInterpreter.applyBatch(state, batch)
+  }
+
+  it should "reject broadcast batches with out-of-bounds target indices" in {
+    val targets = (0 until NumHH).toArray
+    targets(0) = NumHH
+    val batch = BatchedFlow.Broadcast(
+      Funds,
+      ZusIndex,
+      HH,
+      Array.fill(NumHH)(100L),
+      targets,
+      Asset,
+      MechanismId(2)
+    )
+
+    val state = new MutableWorldState(Map(HH -> NumHH, Funds -> NumFunds))
+    an[IllegalArgumentException] should be thrownBy ImperativeInterpreter.applyBatch(state, batch)
   }


### PR DESCRIPTION
## Summary
- add runtime validation for batch dimensions, index bounds, and non-negative amounts in the imperative interpreter
- add regression tests for invalid scatter and broadcast batches
- update README to reflect the current assurance model and runtime invariants
