### PR TITLE
Test distribution against a pure reference model

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Production implementations are **not themselves formally verified**. They are te
 
 - **`Interpreter.scala`** (pure Map-based) — property-based tests (ScalaCheck, 100+ random scenarios per property)
 - **`ImperativeInterpreter.scala`** (Array-based, fast) — tested for bit-for-bit equivalence with `Interpreter.scala` via `EquivalenceSpec`, with runtime validation of batch dimensions, indices, and non-negative amounts
-- **`Distribute.scala`** (N-way distribution with residual plug) — property-based tests checking `sum == total` for arbitrary N
+- **`Distribute.scala`** (N-way distribution with floor-based residual plug) — property-based tests checking `sum == total`, non-negativity, and exact equivalence with a pure reference model
 
 The chain of trust:
 

--- a/src/test/scala/com/boombustgroup/ledger/DistributeReference.scala
+++ b/src/test/scala/com/boombustgroup/ledger/DistributeReference.scala
@@ -1,0 +1,19 @@
+package com.boombustgroup.ledger
+
+/** Pure reference model for production floor-based residual distribution.
+  *
+  * This mirrors [[Distribute.distribute]] without arrays or mutation, so production code can be checked against a simpler executable model.
+  */
+object DistributeReference:
+
+  def distribute(total: Long, shares: List[Long]): List[Long] =
+    require(shares.nonEmpty, "Cannot distribute to zero recipients")
+    require(total >= 0L, "Total must be non-negative")
+    require(shares.forall(_ >= 0L), "Shares must be non-negative")
+    val shareSum = shares.foldLeft(0L)(_ + _)
+    require(shareSum > 0L, "Share sum must be positive")
+
+    val shareSumBigInt = BigInt(shareSum)
+    val prefix         = shares.init.map(share => ((BigInt(total) * BigInt(share)) / shareSumBigInt).toLong)
+    val allocated      = prefix.foldLeft(0L)(_ + _)
+    prefix :+ (total - allocated)

--- a/src/test/scala/com/boombustgroup/ledger/DistributeSpec.scala
+++ b/src/test/scala/com/boombustgroup/ledger/DistributeSpec.scala
@@ -56,3 +56,14 @@ class DistributeSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyCh
     result.sum shouldBe 2L
     result.forall(_ >= 0L) shouldBe true
   }
+
+  it should "match the pure reference model" in {
+    val genTotal  = Gen.choose(1L, 10000000000L)
+    val genSize   = Gen.choose(1, 20)
+    val genShares = genSize.flatMap(n => Gen.listOfN(n, Gen.choose(1L, 10000L)).map(_.toArray))
+    forAll(genTotal, genShares) { (total, shares) =>
+      val result    = Distribute.distribute(total, shares)
+      val reference = DistributeReference.distribute(total, shares.toList).toArray
+      result shouldBe reference
+    }
+  }


### PR DESCRIPTION
## Summary
- add a pure reference implementation for floor-based residual distribution
- test production Distribute.scala for exact equivalence against that reference model
- update README to reflect the new Layer 2 coverage

## Verification
- sbt scalafmtAll test